### PR TITLE
Updated for FLU v8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 4101
 # RLM Web Server (admin gui)
 EXPOSE 4102
 # isv server
-EXPOSE 4500
+EXPOSE 5053
 
 # Add startup script
 COPY ./start.sh /opt/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,20 @@ FROM ubuntu:latest
 
 # Download/Install Foundry Licensing Tools
 RUN apt-get -qq update
-RUN apt-get install wget -y
-RUN wget http://thefoundry.s3.amazonaws.com/tools/FLT/7.1v1/FLT7.1v1-linux-x86-release-64.tgz
-RUN tar xzf FLT7.1v1-linux-x86-release-64.tgz
-RUN rm FLT7.1v1-linux-x86-release-64.tgz
-RUN cd /FLT_7.1v1_linux-x86-release-64RH/ && echo yes | /bin/sh install.sh
+RUN apt-get install wget dpkg -y
+# RUN wget http://thefoundry.s3.amazonaws.com/tools/FLT/7.1v1/FLT7.1v1-linux-x86-release-64.tgz
+# RUN tar xzf FLT7.1v1-linux-x86-release-64.tgz
+# RUN rm FLT7.1v1-linux-x86-release-64.tgz
+# RUN cd /FLT_7.1v1_linux-x86-release-64RH/ && echo yes | /bin/sh install.sh
+
+RUN wget https://thefoundry.s3.amazonaws.com/products/licensing/releases/8.0.0/FoundryLicensingUtility_8.0.0.deb
+RUN dpkg -i FoundryLicensingUtility_8.0.0.deb
 
 # Update Reprise to latest version
-RUN wget http://www.reprisesoftware.com/license_admin_kits/x64_l1.admin.tar.gz
-RUN tar xvf x64_l1.admin.tar.gz
-RUN rm x64_l1.admin.tar.gz
-RUN cp /x64_l1.admin/rlm /usr/local/foundry/LicensingTools7.1/bin/RLM/rlm.foundry
+# RUN wget http://www.reprisesoftware.com/license_admin_kits/x64_l1.admin.tar.gz
+# RUN tar xvf x64_l1.admin.tar.gz
+# RUN rm x64_l1.admin.tar.gz
+# RUN cp /x64_l1.admin/rlm /usr/local/foundry/LicensingTools7.1/bin/RLM/rlm.foundry
 
 VOLUME /opt/rlm/licenses
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,10 @@ FROM ubuntu:latest
 # Download/Install Foundry Licensing Tools
 RUN apt-get update
 RUN apt-get install wget apt-utils -y
-# RUN wget http://thefoundry.s3.amazonaws.com/tools/FLT/7.1v1/FLT7.1v1-linux-x86-release-64.tgz
-# RUN tar xzf FLT7.1v1-linux-x86-release-64.tgz
-# RUN rm FLT7.1v1-linux-x86-release-64.tgz
-# RUN cd /FLT_7.1v1_linux-x86-release-64RH/ && echo yes | /bin/sh install.sh
 
 RUN wget https://thefoundry.s3.amazonaws.com/products/licensing/releases/8.0.0/FoundryLicensingUtility_8.0.0.deb
 RUN apt-get install ./FoundryLicensingUtility_8.0.0.deb -y
 RUN rm FoundryLicensingUtility_8.0.0.deb
-
-# Update Reprise to latest version
-# RUN wget http://www.reprisesoftware.com/license_admin_kits/x64_l1.admin.tar.gz
-# RUN tar xvf x64_l1.admin.tar.gz
-# RUN rm x64_l1.admin.tar.gz
-# RUN cp /x64_l1.admin/rlm /usr/local/foundry/LicensingTools7.1/bin/RLM/rlm.foundry
 
 VOLUME /opt/rlm/licenses
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM ubuntu:latest
 
 # Download/Install Foundry Licensing Tools
-RUN apt-get -qq update
-RUN apt-get install wget dpkg -y
+RUN apt -qq update
+RUN apt install wget apt-utils -y
 # RUN wget http://thefoundry.s3.amazonaws.com/tools/FLT/7.1v1/FLT7.1v1-linux-x86-release-64.tgz
 # RUN tar xzf FLT7.1v1-linux-x86-release-64.tgz
 # RUN rm FLT7.1v1-linux-x86-release-64.tgz
 # RUN cd /FLT_7.1v1_linux-x86-release-64RH/ && echo yes | /bin/sh install.sh
 
 RUN wget https://thefoundry.s3.amazonaws.com/products/licensing/releases/8.0.0/FoundryLicensingUtility_8.0.0.deb
-RUN dpkg -i FoundryLicensingUtility_8.0.0.deb
+RUN apt install ./FoundryLicensingUtility_8.0.0.deb -y
 
 # Update Reprise to latest version
 # RUN wget http://www.reprisesoftware.com/license_admin_kits/x64_l1.admin.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ EXPOSE 5053
 EXPOSE 5054
 # isv server
 EXPOSE 4101
+# additional isv port
+EXPOSE 4500
 
 # Add startup script
 COPY ./start.sh /opt/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ EXPOSE 5053
 EXPOSE 5054
 # isv server
 EXPOSE 4101
+# additional isv port
+#EXPOSE 4500
 
 # Add startup script
 COPY ./start.sh /opt/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM ubuntu:latest
 
 # Download/Install Foundry Licensing Tools
-RUN apt -qq update
-RUN apt install wget apt-utils -y
+RUN apt-get update
+RUN apt-get install wget apt-utils -y
 # RUN wget http://thefoundry.s3.amazonaws.com/tools/FLT/7.1v1/FLT7.1v1-linux-x86-release-64.tgz
 # RUN tar xzf FLT7.1v1-linux-x86-release-64.tgz
 # RUN rm FLT7.1v1-linux-x86-release-64.tgz
 # RUN cd /FLT_7.1v1_linux-x86-release-64RH/ && echo yes | /bin/sh install.sh
 
 RUN wget https://thefoundry.s3.amazonaws.com/products/licensing/releases/8.0.0/FoundryLicensingUtility_8.0.0.deb
-RUN apt install ./FoundryLicensingUtility_8.0.0.deb -y
+RUN apt-get install ./FoundryLicensingUtility_8.0.0.deb -y
+RUN rm FoundryLicensingUtility_8.0.0.deb
 
 # Update Reprise to latest version
 # RUN wget http://www.reprisesoftware.com/license_admin_kits/x64_l1.admin.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,11 @@ RUN rm FoundryLicensingUtility_8.0.0.deb
 VOLUME /opt/rlm/licenses
 
 # rlm server
-EXPOSE 5053
-# admin gui
-EXPOSE 5054
-# isv server
 EXPOSE 4101
-# additional isv port
-#EXPOSE 4500
+# RLM Web Server (admin gui)
+EXPOSE 4102
+# isv server
+EXPOSE 4500
 
 # Add startup script
 COPY ./start.sh /opt/start.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **Goal**
 
-To run Foundry licenses through a Docker container.
+To run the Foundry licenses server v8 through a Docker container.
 
 **Setup**
 

--- a/start.sh
+++ b/start.sh
@@ -8,4 +8,6 @@ hostname -i
 cp /opt/rlm/licenses/foundry_float.lic /opt/foundry_float.lic
 
 # Run the license server directly with the copied license file.
-/opt/FoundryLicensingUtility/bin/FoundryLicensingUtility -l /opt/foundry_float.lic
+echo "Y" | /opt/FoundryLicensingUtility/bin/FoundryLicenseUtility -l /opt/foundry_float.lic
+/opt/FoundryLicensingUtility/bin/flt.run
+watch /opt/FoundryLicensingUtility/bin/FoundryLicenseUtility -s status

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-
+echo "HOSTNAME"
+hostname
 echo "IP ADDRESS:"
 hostname -i
 
@@ -7,4 +8,4 @@ hostname -i
 cp /opt/rlm/licenses/foundry_float.lic /opt/foundry_float.lic
 
 # Run the license server directly with the copied license file.
-/usr/local/foundry/LicensingTools7.1/bin/RLM/rlm.foundry -c /opt/foundry_float.lic
+/opt/FoundryLicensingUtility/bin/FoundryLicensingUtility -l /opt/foundry_float.lic


### PR DESCRIPTION
- Tweaked the Docker container and start.sh to work with the new (very different) version 8 of the Foundry License Utility.

- The extra ISV port is so a client can point to the container on a remote machine to use as the license server. 